### PR TITLE
debian: fix non-systemd build on trusty & precise.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Christian Hammers <ch@debian.org>
 Uploaders: Florian Weimer <fw@debian.org>
-Build-Depends: debhelper (>= 7.0.50~), libncurses5-dev, libreadline-dev, texlive-latex-base, texlive-generic-recommended, libpam0g-dev | libpam-dev, libcap-dev, texinfo (>= 4.7), imagemagick, ghostscript, groff, po-debconf, autotools-dev, hardening-wrapper, libpcre3-dev, gawk, chrpath, libsnmp-dev, git, dh-autoreconf, libjson0, libjson0-dev, dh-systemd, libsystemd-dev, python-ipaddr
+Build-Depends: debhelper (>= 7.0.50~), libncurses5-dev, libreadline-dev, texlive-latex-base, texlive-generic-recommended, libpam0g-dev | libpam-dev, libcap-dev, texinfo (>= 4.7), imagemagick, ghostscript, groff, po-debconf, autotools-dev, hardening-wrapper, libpcre3-dev, gawk, chrpath, libsnmp-dev, git, dh-autoreconf, libjson0, libjson0-dev, dh-systemd (>= 1.5) | base-files, libsystemd-dev | base-files, python-ipaddr, pkg-config
 Standards-Version: 3.9.6
 Homepage: http://www.quagga.net/
 XS-Testsuite: autopkgtest

--- a/debian/rules
+++ b/debian/rules
@@ -4,11 +4,35 @@ export DH_VERBOSE=1
 export DEB_BUILD_HARDENING=1
 export DH_OPTIONS=-v
 
+DPKG_VENDOR      ?= $(shell dpkg-vendor --query Vendor | tr [A-Z] [a-z])
+DEB_DISTRIBUTION  = $(shell dpkg-parsechangelog | sed -ne 's/^Distribution: //p')
+ENABLE_SYSTEMD    = 1
+
+ifeq (ubuntu,$(DPKG_VENDOR))
+  ifeq ($(DEB_DISTRIBUTION),$(filter $(DEB_DISTRIBUTION),precise))
+    $(warning Disabling systemd on $(DPKG_VENDOR) $(DEB_DISTRIBUTION))
+    WANT_SYSTEMD = 0
+  endif
+  ifeq ($(DEB_DISTRIBUTION),$(filter $(DEB_DISTRIBUTION),trusty))
+    $(warning Disabling systemd on $(DPKG_VENDOR) $(DEB_DISTRIBUTION))
+    WANT_SYSTEMD = 0
+  endif
+endif
+
 ifeq ($(WANT_SNMP), 1)
   USE_SNMP=--enable-snmp
   $(warning "DEBIAN: SNMP enabled, sorry for your inconvenience")
 else
   $(warning "DEBIAN: SNMP disabled, see README.Debian")
+endif
+
+ifeq ($(WANT_SYSTEMD), 1)
+  DH_WITH=--with=systemd,autoreconf
+  ENABLE_SYSTEMD=yes
+else
+  DH_WITH=--with=autoreconf
+  ENABLE_SYSTEMD=no
+  $(warning "DEBIAN: systemd disabled")
 endif
 
 ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
@@ -20,7 +44,7 @@ MAKEFLAGS += -j$(DEBIAN_JOBS)
 endif
 
 %:
-	dh $@ --with=systemd,autoreconf --parallel --dbg-package=quagga-dbg --list-missing
+	dh $@ $(DH_WITH) --parallel --dbg-package=quagga-dbg --list-missing
 
 override_dh_auto_configure:
 	# Quagga needs /proc to check some BSD vs Linux specific stuff.
@@ -50,7 +74,7 @@ override_dh_auto_configure:
 		--enable-werror \
 		--enable-gcc-rdynamic \
 		--with-libpam \
-		--enable-systemd=yes \
+		--enable-systemd=$(ENABLE_SYSTEMD) \
 		--enable-poll=yes \
 		--enable-evpn=yes \
 		--enable-cumulus=yes \


### PR DESCRIPTION
- pkg-config was missing.
- libsystemd-dev not applicable to trusty/precise.
- don't pass 'systemd' to dh --with.
- ensure autoconf systemd is disabled.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>