### PR TITLE
zebra: ensure a new FDB entry is permanent

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1496,7 +1496,7 @@ netlink_neigh_update_af_bridge (struct interface *ifp, vlanid_t vid,
     req.n.nlmsg_flags |= (NLM_F_CREATE | NLM_F_APPEND);
   req.n.nlmsg_type = cmd;
   req.ndm.ndm_family = AF_BRIDGE;
-  req.ndm.ndm_state = NUD_NOARP; // Mark as "static"
+  req.ndm.ndm_state = NUD_NOARP | NUD_PERMANENT; // Mark as "static"
   req.ndm.ndm_flags |= NTF_SELF; // Handle by "self", not "master"
 
   addattr_l (&req.n, sizeof (req), NDA_LLADDR, mac, 6);


### PR DESCRIPTION
In ab4d663d507a, the state of a new FDB entry was set to NUD_NOARP
only. However, the kernel require a state to be either NUD_PERMANENT or
NUD_REACHABLE. This is enforced by iproute2. Recent versions default to
NUD_REACHABLE, but in our case, NUD_PERMANENT makes more sense.

Without this change, we get:

    ZEBRA: netlink-cmd (NS 0) error: Invalid argument, type=RTM_NEWNEIGH(28), seq=31, pid=0
    vxlan: RTM_NEWNEIGH with invalid state 0x40