### PR TITLE
Allow for static linking

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1502,7 +1502,7 @@ DEFUNSH (VTYSH_ISISD,
 
 DEFUNSH (VTYSH_RMAP,
 	 route_map,
-	 route_map_cmd,
+	 vtysh_route_map_cmd,
 	 "route-map WORD (deny|permit) <1-65535>",
 	 "Create route-map or enter route-map command mode\n"
 	 "Route map tag\n"
@@ -1928,13 +1928,13 @@ ALIAS (vtysh_exit_vrf,
 /* TODO Implement interface description commands in ripngd, ospf6d
  * and isisd. */
 DEFSH (VTYSH_ZEBRA|VTYSH_RIPD|VTYSH_OSPFD|VTYSH_LDPD,
-       interface_desc_cmd,
+       vtysh_interface_desc_cmd,
        "description .LINE",
        "Interface specific description\n"
        "Characters describing this interface\n")
-       
+
 DEFSH (VTYSH_ZEBRA|VTYSH_RIPD|VTYSH_OSPFD,
-       no_interface_desc_cmd,
+       vtysh_no_interface_desc_cmd,
        "no description",
        NO_STR
        "Interface specific description\n")
@@ -3366,8 +3366,8 @@ vtysh_init_vty (void)
   install_element (RMAP_NODE, &vtysh_end_all_cmd);
   install_element (VTY_NODE, &vtysh_end_all_cmd);
 
-  install_element (INTERFACE_NODE, &interface_desc_cmd);
-  install_element (INTERFACE_NODE, &no_interface_desc_cmd);
+  install_element (INTERFACE_NODE, &vtysh_interface_desc_cmd);
+  install_element (INTERFACE_NODE, &vtysh_no_interface_desc_cmd);
   install_element (INTERFACE_NODE, &vtysh_end_all_cmd);
   install_element (INTERFACE_NODE, &vtysh_exit_interface_cmd);
   install_element (LINK_PARAMS_NODE, &exit_link_params_cmd);
@@ -3438,7 +3438,7 @@ vtysh_init_vty (void)
   install_element (BGP_VNC_L2_GROUP_NODE, &exit_vnc_config_cmd);
 
   install_element (CONFIG_NODE, &key_chain_cmd);
-  install_element (CONFIG_NODE, &route_map_cmd);
+  install_element (CONFIG_NODE, &vtysh_route_map_cmd);
   install_element (CONFIG_NODE, &vtysh_line_vty_cmd);
   install_element (KEYCHAIN_NODE, &key_cmd);
   install_element (KEYCHAIN_NODE, &key_chain_cmd);

--- a/vtysh/vtysh_user.c
+++ b/vtysh/vtysh_user.c
@@ -166,7 +166,7 @@ user_get (const char *name)
 }
 
 DEFUN (banner_motd_file,
-       banner_motd_file_cmd,
+       vtysh_banner_motd_file_cmd,
        "banner motd file FILE",
        "Set banner\n"
        "Banner for motd\n"
@@ -229,5 +229,5 @@ vtysh_user_init (void)
 {
   userlist = list_new ();
   install_element (CONFIG_NODE, &username_nopassword_cmd);
-  install_element (CONFIG_NODE, &banner_motd_file_cmd);
+  install_element (CONFIG_NODE, &vtysh_banner_motd_file_cmd);
 }


### PR DESCRIPTION
Without this patch a static build fails:
```
./bootstrap.sh && ./configure --disable-doc --enable-static --disable-shared && make -j$(nproc)
...
  CC       vtysh_cmd.o
  CCLD     vtysh
../lib/.libs/libzebra.a(command.o):(.data.rel.local+0xc0): multiple definition of `banner_motd_file_cmd'
vtysh_user.o:(.data.rel.local+0x40): first defined here
../lib/.libs/libzebra.a(routemap.o):(.data.rel.local+0x440): multiple definition of `route_map_cmd'
vtysh.o:(.data.rel.local+0x1880): first defined here
../lib/.libs/libzebra.a(if.o):(.data.rel.local+0x240): multiple definition of `no_interface_desc_cmd'
vtysh.o:/home/aaron/Code/src/quagga/vtysh/vtysh.c:2870: first defined here
../lib/.libs/libzebra.a(if.o): In function `show_address_vrf_all':
/home/aaron/Code/src/quagga/lib/if.c:953: multiple definition of `interface_desc_cmd'
vtysh.o:/home/aaron/Code/src/quagga/vtysh/vtysh.c:2838: first defined here
collect2: error: ld returned 1 exit status
Makefile:529: recipe for target 'vtysh' failed
make[2]: *** [vtysh] Error 1
make[2]: Leaving directory '/home/aaron/Code/src/quagga/vtysh'
Makefile:472: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/aaron/Code/src/quagga'
Makefile:404: recipe for target 'all' failed
make: *** [all] Error 2
```